### PR TITLE
Share network to allow tag sources use

### DIFF
--- a/net.puddletag.puddletag.yaml
+++ b/net.puddletag.puddletag.yaml
@@ -15,6 +15,7 @@ finish-args:
   - --filesystem=xdg-music
   - --filesystem=xdg-download
   - --share=ipc
+  - --share=network
   - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=wayland


### PR DESCRIPTION
Currently tag sources such as FreeDB fail with name resolution as there is no network access.